### PR TITLE
SPEECH-195: Parse phrases like three sixty

### DIFF
--- a/tests/test_EN_US.py
+++ b/tests/test_EN_US.py
@@ -40,7 +40,8 @@ class TestEN_US(unittest.TestCase):
             "point oh zero five",
             "a thousand and fifty four",
             "three sixty",
-            "seven eleven")
+            "seven eleven",
+            "three sixty-five")
         test_targets = (2,
             12,
             0,
@@ -68,7 +69,8 @@ class TestEN_US(unittest.TestCase):
             0.005,
             1054,
             360,
-            711
+            711,
+            365
             )
         tests = zip(test_trials, test_targets)
 

--- a/tests/test_EN_US.py
+++ b/tests/test_EN_US.py
@@ -38,7 +38,9 @@ class TestEN_US(unittest.TestCase):
             "nine point oh nine",
             "point eight eight",
             "point oh zero five",
-            "a thousand and fifty four")
+            "a thousand and fifty four",
+            "three sixty",
+            "seven eleven")
         test_targets = (2,
             12,
             0,
@@ -64,7 +66,9 @@ class TestEN_US(unittest.TestCase):
             9.09,
             0.88,
             0.005,
-            1054
+            1054,
+            360,
+            711
             )
         tests = zip(test_trials, test_targets)
 
@@ -99,8 +103,7 @@ class TestEN_US(unittest.TestCase):
         """Test invalid en-US input.
         Ensure that invalid number sequences raise NumberParseException.
         """
-        tests = ("seven eleven",
-            "one one",
+        tests = ("one one",
             "one one one",
             "one one one one",
             "one one one one one",
@@ -119,7 +122,8 @@ class TestEN_US(unittest.TestCase):
             "two thousand point",
             "a five hundred",
             "a six thousand",
-            "six thousand a hundred and twenty")
+            "six thousand a hundred and twenty",
+            "nineteen twenty")
 
         for test in tests:
             try:

--- a/tests/test_EN_US.py
+++ b/tests/test_EN_US.py
@@ -40,8 +40,8 @@ class TestEN_US(unittest.TestCase):
             "point oh zero five",
             "a thousand and fifty four",
             "three sixty",
-            "seven eleven",
-            "three sixty-five")
+            "four twelve",
+            "three sixty five")
         test_targets = (2,
             12,
             0,
@@ -69,7 +69,7 @@ class TestEN_US(unittest.TestCase):
             0.005,
             1054,
             360,
-            711,
+            412,
             365
             )
         tests = zip(test_trials, test_targets)

--- a/words2num/__init__.py
+++ b/words2num/__init__.py
@@ -1,4 +1,4 @@
 from .base import (w2n)
 from .base import w2n as words2num
 from .core import (NumberParseException)
-__version__ = '0.3.2.dev'
+__version__ = '0.3.2'

--- a/words2num/__init__.py
+++ b/words2num/__init__.py
@@ -1,4 +1,4 @@
 from .base import (w2n)
 from .base import w2n as words2num
 from .core import (NumberParseException)
-__version__ = '0.3.1'
+__version__ = '0.3.2.dev'

--- a/words2num/lang_EN_US.py
+++ b/words2num/lang_EN_US.py
@@ -79,6 +79,10 @@ class FST:
             assert n == 100
             self.value *= n
 
+        def f_mul_hundred_and_add(self, n):
+            self.value *= 100
+            self.value += n
+
         def f_ret(self, _):
             return self.value
 
@@ -96,6 +100,8 @@ class FST:
             ('D', 'X'): f_mul,     # 9000
             ('D', 'F'): f_ret,     # 9
             ('T', 'D'): f_add,     # 99
+            ('D', 'T'): f_mul_hundred_and_add,     # 990 (nine ninety)
+            ('D', 'M'): f_mul_hundred_and_add,     # 919 (nine nineteen)
             ('T', 'H'): f_mul_hundred,
             ('T', 'X'): f_mul,     # 90000
             ('T', 'F'): f_ret,     # 90


### PR DESCRIPTION
Added support to parse phrases like: 'three sixty', 'one eighty' or 'three sixty five'.

Basically just added edges from single digits to tens and teens.
Added appropriate tests.

PR 1 of 2 for this ticket. The second will be in the ITN code (aedon/edere in speechrec).