### PR TITLE
Revert "SPEECH-195: Parse phrases like three sixty"

### DIFF
--- a/tests/test_EN_US.py
+++ b/tests/test_EN_US.py
@@ -38,10 +38,7 @@ class TestEN_US(unittest.TestCase):
             "nine point oh nine",
             "point eight eight",
             "point oh zero five",
-            "a thousand and fifty four",
-            "three sixty",
-            "four twelve",
-            "three sixty five")
+            "a thousand and fifty four")
         test_targets = (2,
             12,
             0,
@@ -67,10 +64,7 @@ class TestEN_US(unittest.TestCase):
             9.09,
             0.88,
             0.005,
-            1054,
-            360,
-            412,
-            365
+            1054
             )
         tests = zip(test_trials, test_targets)
 
@@ -105,7 +99,8 @@ class TestEN_US(unittest.TestCase):
         """Test invalid en-US input.
         Ensure that invalid number sequences raise NumberParseException.
         """
-        tests = ("one one",
+        tests = ("seven eleven",
+            "one one",
             "one one one",
             "one one one one",
             "one one one one one",
@@ -124,8 +119,7 @@ class TestEN_US(unittest.TestCase):
             "two thousand point",
             "a five hundred",
             "a six thousand",
-            "six thousand a hundred and twenty",
-            "nineteen twenty")
+            "six thousand a hundred and twenty")
 
         for test in tests:
             try:

--- a/words2num/__init__.py
+++ b/words2num/__init__.py
@@ -1,4 +1,4 @@
 from .base import (w2n)
 from .base import w2n as words2num
 from .core import (NumberParseException)
-__version__ = '0.3.2'
+__version__ = '0.3.1'

--- a/words2num/lang_EN_US.py
+++ b/words2num/lang_EN_US.py
@@ -79,10 +79,6 @@ class FST:
             assert n == 100
             self.value *= n
 
-        def f_mul_hundred_and_add(self, n):
-            self.value *= 100
-            self.value += n
-
         def f_ret(self, _):
             return self.value
 
@@ -100,8 +96,6 @@ class FST:
             ('D', 'X'): f_mul,     # 9000
             ('D', 'F'): f_ret,     # 9
             ('T', 'D'): f_add,     # 99
-            ('D', 'T'): f_mul_hundred_and_add,     # 990 (nine ninety)
-            ('D', 'M'): f_mul_hundred_and_add,     # 919 (nine nineteen)
             ('T', 'H'): f_mul_hundred,
             ('T', 'X'): f_mul,     # 90000
             ('T', 'F'): f_ret,     # 90


### PR DESCRIPTION
Reverts revdotcom/words2num#11

Allowing the transition from single digit to tens/teens is too permissive. It was originally intended to just capture cases like "three sixty" (single digit + tens/teens) but it also allows "twenty four twenty four" to be parsed.